### PR TITLE
Removendo linhas/nós de efeitos sonoros não mais utilizadas em certos scripts/cenas

### DIFF
--- a/scenes/coin.tscn
+++ b/scenes/coin.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=21 format=3 uid="uid://bnye5oi4pmt7m"]
+[gd_scene load_steps=20 format=3 uid="uid://bnye5oi4pmt7m"]
 
 [ext_resource type="Texture2D" uid="uid://berjhcnky6mry" path="res://assets/brackeys_platformer_assets/sprites/coin.png" id="1_aw33r"]
 [ext_resource type="Script" uid="uid://dkqmdtkbmamfy" path="res://scripts/coin.gd" id="1_bxdyx"]
-[ext_resource type="AudioStream" uid="uid://bficu3dww6dvf" path="res://efeitos_sonoros/coletarMoeda.wav" id="4_d14el"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_5pero"]
 atlas = ExtResource("1_aw33r")
@@ -188,9 +187,5 @@ shape = SubResource("CircleShape2D_v72sc")
 libraries = {
 &"": SubResource("AnimationLibrary_vcn5a")
 }
-
-[node name="PickupSound" type="AudioStreamPlayer2D" parent="."]
-position = Vector2(1, 1)
-stream = ExtResource("4_d14el")
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/scenes/roll.tscn
+++ b/scenes/roll.tscn
@@ -1,9 +1,7 @@
-[gd_scene load_steps=14 format=3 uid="uid://wrtooggxrcg"]
+[gd_scene load_steps=12 format=3 uid="uid://wrtooggxrcg"]
 
 [ext_resource type="Script" uid="uid://csrebyll4fq3g" path="res://scripts/roll.gd" id="1_mdf18"]
 [ext_resource type="Texture2D" uid="uid://dtsmu32bn40rn" path="res://assets/brackeys_platformer_assets/sprites/knight.png" id="1_tp1g5"]
-[ext_resource type="AudioStream" uid="uid://d2n3oekemj4t5" path="res://assets/brackeys_platformer_assets/sounds/explosion.wav" id="3_trshq"]
-[ext_resource type="AudioStream" uid="uid://0b7jyjojis7a" path="res://efeitos_sonoros/powerUp.wav" id="4_gfyf2"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_gfyf2"]
 atlas = ExtResource("1_tp1g5")
@@ -70,18 +68,6 @@ tracks/1/keys = {
 "update": 1,
 "values": [false]
 }
-tracks/2/type = "value"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath("PickupSound:playing")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
 
 [sub_resource type="Animation" id="Animation_72cs3"]
 resource_name = "pickuo"
@@ -109,25 +95,13 @@ tracks/1/keys = {
 "update": 1,
 "values": [false]
 }
-tracks/2/type = "value"
+tracks/2/type = "method"
 tracks/2/imported = false
 tracks/2/enabled = true
-tracks/2/path = NodePath("PickupSound:playing")
+tracks/2/path = NodePath(".")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [true]
-}
-tracks/3/type = "method"
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/path = NodePath(".")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/keys = {
 "times": PackedFloat32Array(0.233333),
 "transitions": PackedFloat32Array(1),
 "values": [{
@@ -157,17 +131,9 @@ frame_progress = 0.818159
 position = Vector2(0, 1)
 shape = SubResource("RectangleShape2D_jiwvl")
 
-[node name="PickupSound" type="AudioStreamPlayer2D" parent="."]
-stream = ExtResource("3_trshq")
-volume_db = -30.0
-bus = &"SFX"
-
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {
 &"": SubResource("AnimationLibrary_vcn5a")
 }
-
-[node name="powerUp_som" type="AudioStreamPlayer2D" parent="."]
-stream = ExtResource("4_gfyf2")
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/scenes/skeleton.tscn
+++ b/scenes/skeleton.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=53 format=3 uid="uid://dpypcgou32p63"]
+[gd_scene load_steps=52 format=3 uid="uid://dpypcgou32p63"]
 
 [ext_resource type="Script" uid="uid://b0xs30p3k66ck" path="res://scripts/enemies/skeleton.gd" id="1_ivqcw"]
 [ext_resource type="Texture2D" uid="uid://b1vjhismnd662" path="res://assets/enemies/sprites/Skeleton enemy.png" id="2_ivqcw"]
 [ext_resource type="Script" uid="uid://ce8m4gohaj6o8" path="res://scripts/enemies/collisions/collision_box.gd" id="3_5pgwy"]
-[ext_resource type="AudioStream" uid="uid://dh62sxdj7g4nr" path="res://efeitos_sonoros/inimigoAtingido.wav" id="4_5pgwy"]
 [ext_resource type="Script" uid="uid://dww4fqpeeixor" path="res://scripts/enemies/collisions/attack_collider.gd" id="4_bnirc"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_txkty"]
@@ -400,9 +399,6 @@ enemy = NodePath("..")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="damageCollider" groups=["enemy"]]
 position = Vector2(1, -10.5)
 shape = SubResource("RectangleShape2D_txkty")
-
-[node name="inimigo_atingido" type="AudioStreamPlayer2D" parent="damageCollider"]
-stream = ExtResource("4_5pgwy")
 
 [node name="attackCollider" type="Area2D" parent="." node_paths=PackedStringArray("enemy") groups=["enemy"]]
 collision_layer = 16

--- a/scenes/slime.tscn
+++ b/scenes/slime.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=18 format=3 uid="uid://bmsne38davsio"]
+[gd_scene load_steps=17 format=3 uid="uid://bmsne38davsio"]
 
 [ext_resource type="Texture2D" uid="uid://vmuwgol3hog4" path="res://assets/brackeys_platformer_assets/sprites/slime_green.png" id="1_7b77j"]
 [ext_resource type="Script" uid="uid://djx86ys2t6h1s" path="res://scripts/enemies/slime.gd" id="1_nvlkd"]
 [ext_resource type="Script" uid="uid://ce8m4gohaj6o8" path="res://scripts/enemies/collisions/collision_box.gd" id="3_n6pvg"]
-[ext_resource type="AudioStream" uid="uid://dh62sxdj7g4nr" path="res://efeitos_sonoros/inimigoAtingido.wav" id="4_pjw23"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_n6pvg"]
 atlas = ExtResource("1_7b77j")
@@ -157,9 +156,6 @@ damage = 9999.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
 shape = SubResource("RectangleShape2D_n6pvg")
-
-[node name="inimigo_atingido" type="AudioStreamPlayer2D" parent="Area2D"]
-stream = ExtResource("4_pjw23")
 
 [connection signal="animation_finished" from="AnimatedSprite2D" to="." method="onAnimationFinished"]
 [connection signal="animation_looped" from="AnimatedSprite2D" to="." method="_on_animated_sprite_2d_animation_looped"]

--- a/scripts/coin.gd
+++ b/scripts/coin.gd
@@ -1,7 +1,6 @@
 extends Area2D  
 
 @onready var animation_player: AnimationPlayer = $AnimationPlayer
-@onready var coletarMoeda: AudioStreamPlayer2D = $PickupSound  
 
 func _on_body_entered(_body: Node2D) -> void:
 	if animation_player.current_animation != "pickup":

--- a/scripts/game_manager.gd
+++ b/scripts/game_manager.gd
@@ -5,7 +5,6 @@ var life = 100.0
 var max_life = 100.0
 var imunidade = false
 
-@export var morteSom: AudioStreamPlayer2D
 @onready var score_label: Label = $HUD/ScoreLabel
 @onready var life_label: Label = $HUD/LifeLabel
 @onready var timer: Timer = $Timer

--- a/scripts/pocao.gd
+++ b/scripts/pocao.gd
@@ -1,6 +1,5 @@
 extends Area2D
 
-#@onready var cura_som: AudioStreamPlayer2D = $CuraSom
 var quantidade_cura = 40  
 func _on_body_entered(body: Node2D) -> void:
 	if body is Player:  

--- a/scripts/roll.gd
+++ b/scripts/roll.gd
@@ -2,11 +2,10 @@ extends Area2D
 
 
 @onready var animation_player: AnimationPlayer = $AnimationPlayer
-@onready var powerUp: AudioStreamPlayer2D = $powerUp_som
 
 func _on_body_entered(_body: Node2D) -> void:
 	if animation_player.current_animation != "pickup":
-		if powerUp != null:
-			powerUp.play()
+		if AudioManager.powerUp != null:
+			AudioManager.powerUp.play()
 		GameManager.add_imunity()
 		animation_player.play("pickup")


### PR DESCRIPTION
Devido a implementação do AudioManager, algumas linhas de variáveis e nós filhos de cena se tornaram inúteis, removi eles. O som do powerUp agora é ativado por meio do Audio Manager.